### PR TITLE
linux: add -Wl,--no-undefined shared object link flag

### DIFF
--- a/linux/Makefile
+++ b/linux/Makefile
@@ -54,9 +54,9 @@ endif
 SHLIBEXT=so
 SHLIBCFLAGS=
 ifeq "$(CFG)" "release"
-	SHLIBLDFLAGS="-shared -Wl,-Map,$@_map.txt"
+	SHLIBLDFLAGS="-shared -Wl,-Map,$@_map.txt -Wl,--no-undefined"
 else
-	SHLIBLDFLAGS="-shared -gdwarf-2 -g2 -Wl,-Map,$@_map.txt"
+	SHLIBLDFLAGS="-shared -gdwarf-2 -g2 -Wl,-Map,$@_map.txt -Wl,--no-undefined"
 endif
 
 AR=ar


### PR DESCRIPTION
Helps to avoid stupid situation where something was referenced but wasn't added in the build.

(This was actually made to find missing entities in Linux makefile for one of the mods, but I decided that it makes sense contributing it to the `bs-updated` SDK upstream)